### PR TITLE
Corrections for `/all`

### DIFF
--- a/all/action.yml
+++ b/all/action.yml
@@ -15,12 +15,11 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: echo '::warning::ericcornelissen/odgen-action/all has been deprecated in favor of ericcornelissen/odgen-action with a list of vulnerability types'
-    - name: Scan for Path Traversal vulnerabilities
-      uses: ericcornelissen/odgen-action@v1.1.0
+      run: echo '::warning::ericcornelissen/odgen-action/all has been deprecated in favor of using ericcornelissen/odgen-action with a list of vulnerability types'
+    - uses: ericcornelissen/odgen-action@v1.1.0
       with:
         root: ${{inputs.root}}
-        timeout: ${{steps.timeout.outputs.value}}
+        timeout: ${{inputs.timeout}}
         vulnerability_type: |
           os_command
           code_exec


### PR DESCRIPTION
Relates to #17, https://github.com/ericcornelissen/odgen-action/pull/18#discussion_r2324989246

- Improve grammar in the deprecation warning
- Omit incorrect step name
- Fix timeout input